### PR TITLE
add Unauthorized status code

### DIFF
--- a/src/Uecode/Bundle/ApiKeyBundle/Security/Firewall/ApiKeyListener.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Security/Firewall/ApiKeyListener.php
@@ -40,7 +40,10 @@ class ApiKeyListener implements ListenerInterface
     {
         $request = $event->getRequest();
         if (!$request->query->has('api_key')) {
-            return;
+            $response = new Response();
+            $response->setStatusCode(401);
+            $event->setResponse($response);
+            return ;
         }
 
         $token = new ApiKeyUserToken();


### PR DESCRIPTION
If the request has no api_key attribute in query, symfony take over and return a response with status code 500 "Internal Server error".

It will be better to return response with 401 status code "Unauthorized" to match to restful design ?

what do you think ?
