### PR TITLE
remove PHP5.4 syntax

### DIFF
--- a/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/UserProvider.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/UserProvider.php
@@ -24,7 +24,7 @@ class UserProvider extends FOSUserProvider
     {
         $this->stateless = true;
 
-        return $this->userManager->findUserBy(['apiKey' => $apiKey]);
+        return $this->userManager->findUserBy(array('apiKey' => $apiKey));
     }
 
     /**


### PR DESCRIPTION
`composer.json` require `"php" >= "5.3.0"` but UserProvider use PHP 5.4 specific syntax.

Thx,
