### PR TITLE
Support Doctrine ODM as well as Doctrine ORM

### DIFF
--- a/src/Uecode/Bundle/ApiKeyBundle/Document/ApiKeyUser.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Document/ApiKeyUser.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+use Uecode\Bundle\ApiKeyBundle\Model\ApiKeyUser as BaseUser;
+
+class ApiKeyUser extends BaseUser
+{
+    /**
+     * @MongoDB\String
+     */
+    protected $apiKey;
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Entity/ApiKeyUser.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Entity/ApiKeyUser.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Uecode\Bundle\ApiKeyBundle\Model\ApiKeyUser as BaseUser;
+
+/**
+ * @MappedSuperclass
+ */
+class ApiKeyUser extends BaseUser
+{
+    /**
+     * @ORM\Column(name="api_key", type="string", length=255, nullable=true)
+     */
+    protected $apiKey;
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Model/ApiKeyUser.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Model/ApiKeyUser.php
@@ -2,22 +2,13 @@
 
 namespace Uecode\Bundle\ApiKeyBundle\Model;
 
-use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\MappedSuperclass;
 use FOS\UserBundle\Model\User as BaseUser;
 use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 
-/**
- * @MappedSuperclass
- */
 class ApiKeyUser extends BaseUser implements UserInterface, AdvancedUserInterface, BaseUserInterface
 {
-    /**
-     * @ORM\Column(name="api_key", type="string", length=255, nullable=true)
-     */
     protected $apiKey;
 
     public function __construct()


### PR DESCRIPTION
This PR allows for any kind of database to be used. The approach used is the same as FOSUserBundle's: a base model is provided (`Model` namespace) and then extended (`Entity` namespace for doctrine ORM and `Document` for ODM).

**N.B**: there is a BC break as the `Model` namespace is now really used to store the model (and is hence "ORM annotations"-free). We could avoid this BC break by moving the real model into another namespace (what would be its name?) but I tried to be consistent while naming things. WDYT?
