### PR TITLE
API keys can be extracted from different sources

### DIFF
--- a/src/Uecode/Bundle/ApiKeyBundle/DependencyInjection/Configuration.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/DependencyInjection/Configuration.php
@@ -15,6 +15,21 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('uecode_api_key');
 
+        $rootNode
+            ->children()
+                ->scalarNode('delivery')
+                    ->defaultValue('query')
+                    ->validate()
+                        ->ifNotInArray(array('query', 'header'))
+                        ->thenInvalid('Unknown authentication delivery type "%s".')
+                     ->end()
+                 ->end()
+                ->scalarNode('parameter_name')
+                    ->defaultValue('api_key')
+                 ->end()
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 }

--- a/src/Uecode/Bundle/ApiKeyBundle/DependencyInjection/UecodeApiKeyExtension.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/DependencyInjection/UecodeApiKeyExtension.php
@@ -22,6 +22,14 @@ class UecodeApiKeyExtension extends Extension
             new FileLocator(__DIR__.'/../Resources/config')
         );
         $loader->load('services.yml');
+
+        $this->defineKeyExtractor($config, $container);
+    }
+
+    private function defineKeyExtractor(array $config, ContainerBuilder $container)
+    {
+        $container->setParameter('uecode.api_key.parameter_name', $config['parameter_name']);
+        $container->setAlias('uecode.api_key.extractor', 'uecode.api_key.extractor.'.$config['delivery']);
     }
 }
 

--- a/src/Uecode/Bundle/ApiKeyBundle/Extractor/HeaderExtractor.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Extractor/HeaderExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Extractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Extracts API keys from request headers.
+ *
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ */
+class HeaderExtractor implements KeyExtractor
+{
+    private $parameterName;
+
+    /**
+     * @param string $parameterName The name of the URL parameter containing the API key.
+     */
+    public function __construct($parameterName)
+    {
+        $this->parameterName = $parameterName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasKey(Request $request)
+    {
+        return $request->headers->has($this->parameterName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extractKey(Request $request)
+    {
+        return $request->headers->get($this->parameterName);
+    }
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Extractor/KeyExtractor.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Extractor/KeyExtractor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Extractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ */
+interface KeyExtractor
+{
+    /**
+     * Tells if the given requests carries an API key.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    function hasKey(Request $request);
+
+    /**
+     * Extract the API key from thhe given request
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    function extractKey(Request $request);
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Extractor/QueryExtractor.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Extractor/QueryExtractor.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Extractor;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Extracts API keys from a request query string.
+ *
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ */
+class QueryExtractor implements KeyExtractor
+{
+    private $parameterName;
+
+    /**
+     * @param string $parameterName The name of the URL parameter containing the API key.
+     */
+    public function __construct($parameterName)
+    {
+        $this->parameterName = $parameterName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasKey(Request $request)
+    {
+        return $request->query->has($this->parameterName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extractKey(Request $request)
+    {
+        return $request->query->get($this->parameterName);
+    }
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Resources/config/services.yml
+++ b/src/Uecode/Bundle/ApiKeyBundle/Resources/config/services.yml
@@ -3,6 +3,9 @@ parameters:
     uecode.api_key.provider.api_key.class:       Uecode\Bundle\ApiKeyBundle\Security\Authentication\Provider\ApiKeyProvider
     uecode.api_key.listener.api_key.class:       Uecode\Bundle\ApiKeyBundle\Security\Firewall\ApiKeyListener
 
+    uecode.api_key.extractor.query.class:        Uecode\Bundle\ApiKeyBundle\Extractor\QueryExtractor
+    uecode.api_key.extractor.header.class:       Uecode\Bundle\ApiKeyBundle\Extractor\HeaderExtractor
+
 services:
     uecode.api_key.provider.user_provider:
         class: %uecode.api_key.provider.user_provider.class%
@@ -12,5 +15,13 @@ services:
         arguments: [""]
     uecode.api_key.listener.api_key:
         class: %uecode.api_key.listener.api_key.class%
-        arguments: [@security.context, @security.authentication.manager]
+        arguments: [@security.context, @security.authentication.manager, @uecode.api_key.extractor]
 
+    uecode.api_key.extractor.query:
+        class: %uecode.api_key.extractor.query.class%
+        arguments: [%uecode.api_key.parameter_name%]
+        public: false
+    uecode.api_key.extractor.header:
+        class: %uecode.api_key.extractor.header.class%
+        arguments: [%uecode.api_key.parameter_name%]
+        public: false


### PR DESCRIPTION
This commit allows API keys to be extracted both from request query
string and request headers.
The extraction technique can be configured and the parameter holding the
API key can also be changed.

There is no BC break with this commit as default settings match the
previous behavior.
