### PR TITLE
Allows user to use custom user provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ApiKey Bundle
 
 Creates an avenue for using ApiKey authentication for Symfony2. Requires FOSUserBundle.
 
-## Installation
+# Installation
 
 Requires composer, install as follows
 
@@ -11,7 +11,7 @@ Requires composer, install as follows
 composer require uecode/api-key-bundle dev-master
 ```
 
-#### Enable Bundle
+## Enable Bundle
 
 Place in your `AppKernel.php` to enable the bundle
 
@@ -36,6 +36,15 @@ uecode_api_key:
     parameter_name: some_value # defaults to `api_key`
 ```
 
+### Update user provider
+
+This bundle provides two ways to work with User model:
+
+1. use model and user provider provided by this bundle
+2. use custom user provider
+
+### Use model provided by this bundle
+
 #### Entities
 
 Assuming you already have a `User` class that extends the `FOSUserBundle`'s base user model,
@@ -43,7 +52,7 @@ change that extend, so its extending `Uecode\Bundle\ApiKeyBundle\Model\ApiKeyUse
 
 Then update your schema.
 
-#### Set up security
+#### Change used user provider
 
 In your security, change your provider to the service `uecode.api_key.provider.user_provider`
 
@@ -64,7 +73,30 @@ security:
             id: uecode.api_key.provider.user_provider
 ```
 
-After adding that, you can now add `api_key: true`, and `stateless: true` to any of your firewalls. 
+
+### Use custom user provider
+
+To work with this bundle your user provider should implement ```ApiKeyUserProviderInterface```.
+It consist of one method for loading user by their apiKey.
+You should implement this interface for user provider which used in your api firewall:
+
+```php
+use Uecode\Bundle\ApiKeyBundle\Security\Authentication\Provider\ApiKeyUserProviderInterface;
+
+class MyCustomUserProvider implements ApiKeyUserProviderInterface {
+// ...
+
+public function loadUserByApiKey($apiKey)
+{
+    return $this->userManager->findUserBy(array('apiKey' => $apiKey));
+}
+
+}
+```
+
+## Change security settings
+
+You can now add `api_key: true`, and `stateless: true` to any of your firewalls. 
 
 For Example:
 

--- a/src/Uecode/Bundle/ApiKeyBundle/Model/ApiKeyUser.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Model/ApiKeyUser.php
@@ -6,6 +6,7 @@ use FOS\UserBundle\Model\User as BaseUser;
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Uecode\Bundle\ApiKeyBundle\Util\ApiKeyGenerator;
 
 class ApiKeyUser extends BaseUser implements UserInterface, AdvancedUserInterface, BaseUserInterface
 {
@@ -13,12 +14,12 @@ class ApiKeyUser extends BaseUser implements UserInterface, AdvancedUserInterfac
 
     public function __construct()
     {
-        $this->generateApiKey();
         parent::__construct();
+        $this->setApiKey(ApiKeyGenerator::generate());
     }
 
     /**
-     * @param mixed $apiKey
+     * @param string $apiKey
      */
     public function setApiKey($apiKey)
     {
@@ -26,24 +27,10 @@ class ApiKeyUser extends BaseUser implements UserInterface, AdvancedUserInterfac
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getApiKey()
     {
         return $this->apiKey;
-    }
-
-    /**
-     * Generates an API Key
-     */
-    public function generateApiKey()
-    {
-        $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        $apikey     = '';
-        for ($i = 0; $i < 64; $i++) {
-            $apikey .= $characters[rand(0, strlen($characters) - 1)];
-        }
-        $apikey = base64_encode(sha1(uniqid('ue' . rand(rand(), rand())) . $apikey));
-        $this->apiKey = $apikey;
     }
 }

--- a/src/Uecode/Bundle/ApiKeyBundle/Resources/config/services.yml
+++ b/src/Uecode/Bundle/ApiKeyBundle/Resources/config/services.yml
@@ -5,7 +5,9 @@ parameters:
 
     uecode.api_key.extractor.query.class:        Uecode\Bundle\ApiKeyBundle\Extractor\QueryExtractor
     uecode.api_key.extractor.header.class:       Uecode\Bundle\ApiKeyBundle\Extractor\HeaderExtractor
-
+    
+    uecode.api_key.generator.class:              Uecode\Bundle\ApiKeyBundle\Util\ApiKeyGenerator
+    
 services:
     uecode.api_key.provider.user_provider:
         class: %uecode.api_key.provider.user_provider.class%
@@ -24,4 +26,7 @@ services:
     uecode.api_key.extractor.header:
         class: %uecode.api_key.extractor.header.class%
         arguments: [%uecode.api_key.parameter_name%]
+        public: false
+    uecode.api_key.generator:
+        class: %uecode.api_key.generator.class%
         public: false

--- a/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/ApiKeyProvider.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/ApiKeyProvider.php
@@ -9,6 +9,7 @@ use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use FOS\UserBundle\Model\UserInterface;
 use Uecode\Bundle\ApiKeyBundle\Security\Authentication\Token\ApiKeyUserToken;
+use Uecode\Bundle\ApiKeyBundle\Security\Authentication\Provider\ApiKeyUserProviderInterface;
 
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
@@ -58,9 +59,9 @@ class ApiKeyProvider implements AuthenticationProviderInterface
      * @return bool|ApiKeyUserToken
      * @throws AuthenticationException
      */
-    protected function doAuth(UserProviderInterface $provider, TokenInterface $token)
+    protected function doAuth($provider, TokenInterface $token)
     {
-        if (!method_exists($provider, 'loadUserByApiKey')) {
+        if (! $provider instanceof ApiKeyUserProviderInterface) {
             return false;
         }
 

--- a/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/ApiKeyUserProviderInterface.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/ApiKeyUserProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Uecode\Bundle\ApiKeyBundle\Security\Authentication\Provider;
+
+/**
+ * @author Gennady Telegin <gtelegin@gmail.com>
+ */
+interface ApiKeyUserProviderInterface
+{
+    /**
+     * @param string $apiKey
+     *
+     * @return UserInterface
+     */
+    public function loadUserByApiKey($apiKey);
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/UserProvider.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Security/Authentication/Provider/UserProvider.php
@@ -8,7 +8,7 @@ use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
  */
-class UserProvider extends FOSUserProvider
+class UserProvider extends FOSUserProvider implements ApiKeyUserProviderInterface
 {
     /**
      * @var bool Stateless Authentication?
@@ -16,9 +16,7 @@ class UserProvider extends FOSUserProvider
     private $stateless = false;
 
     /**
-     * @param $apiKey
-     *
-     * @return UserInterface
+     * {@inheritdoc}
      */
     public function loadUserByApiKey($apiKey)
     {

--- a/src/Uecode/Bundle/ApiKeyBundle/Util/ApiKeyGenerator.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Util/ApiKeyGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Util;
+
+/**
+ * @author Gennady Telegin <gtelegin@gmail.com>
+ */
+class ApiKeyGenerator implements ApiKeyGeneratorInterface
+{
+    private $characterSet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    private $apiKeyLength = 64;
+
+    public function generateApiKey()
+    {
+        return self::generate($this->characterSet, $this->apiKeyLength);
+    }
+
+    public static function generate($characterSet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $apiKeyLength = 64)
+    {
+        $characterSetLength = strlen($characterSet);
+
+        $apikey     = '';
+        for ($i = 0; $i < $apiKeyLength; ++$i) {
+            $apikey .= $characterSet[rand(0, $characterSetLength - 1)];
+        }
+
+        return rtrim(base64_encode(sha1(uniqid('ue' . rand(rand(), rand())) . $apikey)), '=');
+    }
+}

--- a/src/Uecode/Bundle/ApiKeyBundle/Util/ApiKeyGeneratorInterface.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Util/ApiKeyGeneratorInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Uecode\Bundle\ApiKeyBundle\Util;
+
+/**
+ * @author Gennady Telegin <gtelegin@gmail.com>
+ */
+interface ApiKeyGeneratorInterface
+{
+    public function generateApiKey();
+}


### PR DESCRIPTION
I already has my own user provider in my project and user model and don't like the idea, that I need extends some new classes to work with apikey based authentication.

This PR allows to use custom user provider which implements interface ApiKeyUserProviderInterface.

Should be backward compatible.