### PR TITLE
Update ApiKeyListener.php

### DIFF
--- a/src/Uecode/Bundle/ApiKeyBundle/Security/Firewall/ApiKeyListener.php
+++ b/src/Uecode/Bundle/ApiKeyBundle/Security/Firewall/ApiKeyListener.php
@@ -48,9 +48,6 @@ class ApiKeyListener implements ListenerInterface
         $request = $event->getRequest();
 
         if (!$this->keyExtractor->hasKey($request)) {
-            $response = new Response();
-            $response->setStatusCode(401);
-            $event->setResponse($response);
             return ;
         }
 


### PR DESCRIPTION
Not set response if not found api key, because the same route can have multiple firewalls/listeners (for example when allow anonymous access to resources under firewall).