### PR TITLE
Quoting the scalars

### DIFF
--- a/src/Uecode/Bundle/ApiKeyBundle/Resources/config/services.yml
+++ b/src/Uecode/Bundle/ApiKeyBundle/Resources/config/services.yml
@@ -11,26 +11,26 @@ parameters:
     
 services:
     uecode.api_key.provider.user_provider:
-        class: %uecode.api_key.provider.user_provider.class%
+        class: "%uecode.api_key.provider.user_provider.class%"
         arguments: ["@fos_user.user_manager"]
     uecode.api_key.provider.email_user_provider:
-        class: %uecode.api_key.provider.email_user_provider.class%
+        class: "%uecode.api_key.provider.email_user_provider.class%"
         arguments: ["@fos_user.user_manager"]
     uecode.api_key.provider.api_key:
-        class: %uecode.api_key.provider.api_key.class%
+        class: "%uecode.api_key.provider.api_key.class%"
         arguments: [""]
     uecode.api_key.listener.api_key:
-        class: %uecode.api_key.listener.api_key.class%
+        class: "%uecode.api_key.listener.api_key.class%"
         arguments: ["@security.token_storage", "@security.authentication.manager", "@uecode.api_key.extractor"]
 
     uecode.api_key.extractor.query:
-        class: %uecode.api_key.extractor.query.class%
+        class: "%uecode.api_key.extractor.query.class%"
         arguments: [%uecode.api_key.parameter_name%]
         public: false
     uecode.api_key.extractor.header:
-        class: %uecode.api_key.extractor.header.class%
+        class: "%uecode.api_key.extractor.header.class%"
         arguments: [%uecode.api_key.parameter_name%]
         public: false
     uecode.api_key.generator:
-        class: %uecode.api_key.generator.class%
+        class: "%uecode.api_key.generator.class%"
         public: false


### PR DESCRIPTION
Not quoting the scalar "%uecode.api_key.provider.user_provider.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/home/nikola/Projects/orioly/orioly-symfony/vendor/uecode/api-key-bundle/src/Uecode/Bundle/ApiKeyBundle/DependencyInjection/../Resources/config/services.yml" on line 13.